### PR TITLE
fix:이미지 다운로드 시 CORS 정책 따르는 사이트 이미지 출력 안됨 수정

### DIFF
--- a/src/components/ThumbCreator.jsx
+++ b/src/components/ThumbCreator.jsx
@@ -89,8 +89,11 @@ function ThumbCreator() {
   function downloadThumbnail() {
     const target = document.getElementById('thumbnail');
     if (!target) return;
-    console.log(target);
-    html2canvas(target).then((canvas) => {
+    html2canvas(target, {
+      letterRendering: 1,
+      allowTaint: true, // cross-origin 이미지를 캔버스에 삽입할지
+      useCORS: true, // Whether to attempt to load images from a server using CORS
+    }).then((canvas) => {
       const link = document.createElement('a');
       document.body.appendChild(link);
       link.href = canvas.toDataURL('image/png');


### PR DESCRIPTION
# 썸네일 배경 외부 이미지 사용 시 문제 발생
- 썸네일 배경을 단색, 그라디언트로 설정하는 경우 문제 없이 다운로드 되지만,
- CORS 정책을 따르는 외부 사이트의 이미지 링크를 사용할 시에 배경이 설정되지 않는 문제를 겪었다.
> CROS란?
>CORS(Cross-Origin Resource Sharing)는 출처가 다른 자원들을 공유한다는 뜻으로, 한 출처에 있는 자원에서 다른 출처에 있는 자원에 접근하도록 하는 개념
- html2canvas에 옵션 설정을 통해 이런 문제를 해결할 옵션이 있었다.
```js
  function downloadThumbnail() {
    const target = document.getElementById('thumbnail');
    if (!target) return;
    html2canvas(target, {
      letterRendering: 1,
      allowTaint: true, // cross-origin 이미지를 캔버스에 삽입할지
      useCORS: true, // Whether to attempt to load images from a server using CORS
    }).then((canvas) => {
      ...
    });
  }```