### PR TITLE
fix:일부 className에 대한 nesting 해제

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,6 +1,6 @@
 @import url('./reset.css');
 
-$background-color: rgba(255, 255, 255, 0.8);
+$background-color: rgba(255, 255, 255, 0.9);
 
 .App {
   display: flex;
@@ -25,11 +25,12 @@ $background-color: rgba(255, 255, 255, 0.8);
   .thumb {
     display: flex;
     flex-direction: column;
-    .line {
-      width: 60%;
-      border: 1px solid white;
-    }
   }
+}
+
+.line {
+  width: 60%;
+  border: 1px solid white;
 }
 
 .options {
@@ -49,8 +50,10 @@ $background-color: rgba(255, 255, 255, 0.8);
 }
 
 .thumbs-preview {
+  height: 90vh;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 10px;
+  overflow: scroll;
 }


### PR DESCRIPTION
- 제목과 소제목 사이의 구분선이 임시저장된 썸네일에는 적용되지 않는 문제
- scss파일에서 nesting 밖으로 꺼냄으로써 해결