### PR TITLE
fix:썸네일 캔버스 크기 설정 시 렌더링 오류 수정

### DIFF
--- a/src/components/ThumbCreator.jsx
+++ b/src/components/ThumbCreator.jsx
@@ -13,6 +13,8 @@ function ThumbCreator(props) {
   // thumbnail state
   const [width, setWidth] = useState(1280);
   const [height, setHeight] = useState(720);
+  const [viewWidth, setViewWidth] = useState(1280);
+  const [viewHeight, setViewHeigth] = useState(720);
   const [background, setBackground] = useState(
     `url(https://images.unsplash.com/photo-1685895324391-ba9e104fd2d0?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D)`
   );
@@ -29,20 +31,20 @@ function ThumbCreator(props) {
     const size = Number(event.target.getAttribute('size-info'));
     switch (size) {
       case 1:
-        setWidth(600);
-        setHeight(600);
+        setViewWidth(600);
+        setViewHeigth(600);
         break;
       case 2:
-        setWidth(1280);
-        setHeight(720);
+        setViewWidth(1280);
+        setViewHeigth(720);
         break;
       case 3:
-        setWidth(720);
-        setHeight(540);
+        setViewWidth(720);
+        setViewHeigth(540);
         break;
       default:
-        setWidth(1280);
-        setHeight(720);
+        setViewWidth(1280);
+        setViewHeigth(720);
     }
   }
 
@@ -51,8 +53,8 @@ function ThumbCreator(props) {
     const x = preview.clientWidth;
     const y = preview.clientHeight;
     let flag = false;
-    let tempWidth = width;
-    let tempHeight = height;
+    let tempWidth = viewWidth;
+    let tempHeight = viewHeight;
     while (!flag) {
       if (tempWidth >= x || tempHeight >= y) {
         tempWidth *= 0.8;
@@ -63,7 +65,7 @@ function ThumbCreator(props) {
     }
     setWidth(tempWidth);
     setHeight(tempHeight);
-  }, [width, height]);
+  }, [viewWidth, viewHeight]);
 
   /** 사용자가 선택한 옵션에 따라 배경을 그리는 함수 */
   function setBackgroundImage(event) {

--- a/src/components/ThumbStorage.jsx
+++ b/src/components/ThumbStorage.jsx
@@ -13,7 +13,7 @@ import {
 import * as B from '../styles/Button.styled';
 
 function ThumbStorage(props) {
-  /** 현재 생성하고 있는 썸네일을 다운로드 하는 함수 */
+  /** 임시저장된 썸네일을 다운로드 하는 함수 */
   function downloadThumbnail(targetId) {
     const target = document.getElementById(`capture${targetId}`);
     if (!target) return;
@@ -31,7 +31,7 @@ function ThumbStorage(props) {
     });
   }
 
-  /** 현재 생성하고 있는 썸네일을 클립보드로 복사하는 함수 */
+  /** 임시저장된 썸네일을 클립보드로 복사하는 함수 */
   function clipboardThumbnail(targetId) {
     const target = document.getElementById(`capture${targetId}`);
     if (!target) return;
@@ -90,6 +90,7 @@ function ThumbStorage(props) {
             클립보드
           </B.Button>
         </div>
+        <hr></hr>
       </div>
     );
   });


### PR DESCRIPTION
사용자가 원하는 비율로 썸네일 캔버스 크기를 설정할 때 캔버스를 담는 preview div보다 캔버스 크기가 크면 작아지도록 코드가 구현되어 있는데, 크기가 작아지기 전에 화면에 preivew보다 큰 썸네일 캔버스가 순간적으로 렌더링 되는 문제를 해결함
- 사용자가 선택하는 비율에 따라 결정되는 가로, 세로의 크기를 viewWidth, viewHeight라는 state에 먼저 담고,
- viewWidth, viewHegith가 preview보다 작아질 때 그 크기로 setWidth, setHeight 해주는 방식으로 구현